### PR TITLE
Add documentation of filetypes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is a vim syntax plugin for Ansible 2.0, it supports YAML playbooks, Jinja2 
 - Jinja2 templates are detected if they have a *.j2* suffix
 - Files named `hosts` will be treated as Ansible hosts files
 
+You can also set the filetype to `ansible`, `ansible_template`, or `ansible_hosts` if auto-detection does not work (e.g. `:set ft=ansible`).
+
 This plugin should be quite reliable, as it sources the original formats and simply modifies the highlights as appropriate. This also enables a focus on simplicity and configurability instead of patching bad syntax detection.
 
 ##### examples


### PR DESCRIPTION
In the event that auto-detection doesn't work, it's good to know the filetypes used so you can manually override as needed.