### PR TITLE
Add ansible_hosts ftplugin

### DIFF
--- a/ftplugin/ansible_hosts.vim
+++ b/ftplugin/ansible_hosts.vim
@@ -1,0 +1,9 @@
+if exists("b:did_ftplugin")
+  finish
+else
+  let b:did_ftplugin = 1
+endif
+
+setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions-=c
+
+let b:undo_ftplugin = "setl comments< commentstring< formatoptions<"


### PR DESCRIPTION
This PR adds an ftplugin for hosts files. It sets comment strings (used by plugins such as [vim-commentary](https://github.com/tpope/vim-commentary)), and disables auto-wrapping of lines while typing in insert mode.