### PR TITLE
Debug ft detection

### DIFF
--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -12,6 +12,6 @@ function! s:isAnsible()
   return 0
 endfunction
 
-:au BufNewFile,BufRead * if !did_filetype() && s:isAnsible() | setf ansible | en
+:au BufNewFile,BufRead * if s:isAnsible() | set ft=ansible | en
 :au BufNewFile,BufRead *.j2 set ft=ansible_template
 :au BufNewFile,BufRead hosts set ft=ansible_hosts


### PR DESCRIPTION
This PR fixes 2 things:
- First, using `!did_filetype()` is very inefficient, because in most cases vim will autodetect the file as YAML before loading ansible-vim. But we want to override the filetype.
- Secondly, `setf ansible` doesn't seems to work for me in this context (I don't know why). It's working fine with `set ft=ansible`.

Thanks.