### PR TITLE
extend file type detect to match if ansible in path

### DIFF
--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -1,6 +1,7 @@
 function! s:isAnsible()
   let filepath = expand("%:p")
   let filename = expand("%:t")
+  if filepath =~ '\v/(ansible|Ansible)/.*\.ya?ml$' | return 1 | en
   if filepath =~ '\v/(tasks|roles|handlers)/.*\.ya?ml$' | return 1 | en
   if filepath =~ '\v/(group|host)_vars/' | return 1 | en
   if filename =~ '\v(playbook|site|main)\.ya?ml$' | return 1 | en


### PR DESCRIPTION
Adding support for file type detection to match if either "ansible" or "Ansible" in the file path.  This is useful when working with multiple stand alone playbooks stored in an "ansible" directory.