### PR TITLE
add local.yml to autodetected filenames

### DIFF
--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -3,7 +3,7 @@ function! s:isAnsible()
   let filename = expand("%:t")
   if filepath =~ '\v/(tasks|roles|handlers)/.*\.ya?ml$' | return 1 | en
   if filepath =~ '\v/(group|host)_vars/' | return 1 | en
-  if filename =~ '\v(playbook|site|main)\.ya?ml$' | return 1 | en
+  if filename =~ '\v(playbook|site|main|local)\.ya?ml$' | return 1 | en
 
   let shebang = getline(1)
   if shebang =~# '^#!.*/bin/env\s\+ansible-playbook\>' | return 1 | en


### PR DESCRIPTION
`local.yml` is the default playbook name used by ansible-pull, which is hardcoded in ansible.