### PR TITLE
Jinja2 commentstring

### DIFF
--- a/ftplugin/ansible_template.vim
+++ b/ftplugin/ansible_template.vim
@@ -1,0 +1,1 @@
+setlocal commentstring={#\ %s\ #}

--- a/ftplugin/jinja2.vim
+++ b/ftplugin/jinja2.vim
@@ -1,0 +1,1 @@
+setlocal commentstring={#\ %s\ #}


### PR DESCRIPTION
There is no vim syntax file that correctly sets `commentstring` for Jinja2, breaking muscle memories around the world. 

This should also impact the ansible_template filetype. 