### PR TITLE
Improve generate.py script

### DIFF
--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -11,11 +11,7 @@ from ansible.utils.module_docs import get_docstring
 def get_documents():
     for root, dirs, files in os.walk(os.path.dirname(ansible.modules.__file__)):
         for f in files:
-            if f == '__init__.py':
-                continue
-            if f.endswith('.pyc'):
-                continue
-            if f.endswith('.ps1'):
+            if f == '__init__.py' or not f.endswith('py'):
                 continue
             documentation = get_docstring(os.path.join(root, f))[0]
             if documentation is None:


### PR DESCRIPTION
Only look for .py files when generating the snippets. Also make the
generate.py executable.

Improve the logic to avoid parsing files that are not Python source files. The script was capturing .pyo files (optimized python file) and errors like `[ERROR]: unable to parse /usr/lib/python2.7/site-packages/ansible/modules/database/proxysql/proxysql_global_variables.pyo` was being raised.