### PR TITLE
Use standard YAML key value pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use your favorite plugin manager, or try [vim-plug](https://github.com/junegunn/
 **vim-plug:** `Plug 'pearofducks/ansible-vim'`
 
 **vim-plug with post-update hook:** `Plug 'pearofducks/ansible-vim', { 'do':
-'./UltiSnips/generate.py' }`
+'cd ./UltiSnips; python2 generate.py' }`
 
 **vundle:** `Plugin 'pearofducks/ansible-vim'`
 

--- a/UltiSnips/README.md
+++ b/UltiSnips/README.md
@@ -3,6 +3,15 @@ Generate Snippets Based on Ansible Modules
 
 A script to generate `UltiSnips` based on ansible code on the fly.
 
+Script parameters
+-----------------
+There are a couple of optional arguments for the script.
+
+  * --output: Output filename (Default: ansible.snippets)
+  * --style: YAML formatting style for snippets
+             Choices: multiline (default), dictionary
+  * --sort: Whether to sort module arguments (default: no)
+
 For Users
 ---------
 We display option description somewhere, however, there are some special formatters in it.

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -22,7 +22,7 @@ def get_documents():
 def to_snippet(document):
     snippet = []
     if 'options' in document:
-        options = sorted(document['options'].items(), key=lambda x: x[1].get("required", False), reverse=True)
+        options = sorted(document['options'].items(), key=lambda x: x[1].get("required") or x[0])
         for index, (name, option) in enumerate(options, 1):
             if 'choices' in option:
                 default = option.get('default')

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -40,9 +40,9 @@ def to_snippet(document):
             else:
                 value = "# " + option.get('description', [''])[0]
             if name == 'free_form':  # special for command/shell
-                snippet.append('\t${%d:%s=%s}' % (index, name, value))
+                snippet.append('\t${%d:%s: %s}' % (index, name, value))
             else:
-                snippet.append('\t%s=${%d:%s}' % (name, index, value))
+                snippet.append('\t%s: ${%d:%s}' % (name, index, value))
 
         # insert a line to seperate required/non-required field
         for index, (_, option) in enumerate(options):
@@ -51,7 +51,7 @@ def to_snippet(document):
                     snippet.insert(index, '')
                 break
 
-    snippet.insert(0, '%s:%s' % (document['module'], ' >' if len(snippet) else ''))
+    snippet.insert(0, '%s:' % (document['module']))
     snippet.insert(0, 'snippet %s "%s" b' % (document['module'], document['short_description']))
     snippet.append('')
     snippet.append('endsnippet')


### PR DESCRIPTION
Hi, I like the standard syntax for defining Ansible modules. (using `attr: value` on a new line instead of using `>` on the first line and then `attr=value` on subsequent lines)

It's everywhere in Ansible documentation and is also preferred by Ansible team.

Maybe add an option to toggle this behaviour when generating the snippets? 
