### PR TITLE
Add top-level templates and files to path

### DIFF
--- a/ftplugin/ansible.vim
+++ b/ftplugin/ansible.vim
@@ -2,4 +2,4 @@
 if exists('+regexpengine') && ('&regexpengine' == 0)
   setlocal regexpengine=1
 endif
-set path+=./../templates,./../files
+set path+=./../templates,./../files,templates,files


### PR DESCRIPTION
Assuming two things:

1.  that vim is started from top-level ansible dir and
2. that top-level dir is the playbook_dir (which is the default)

and according to somewhat confusing documentation at https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/playbook_pathing.rst

...are `$PWD/templates` and `$PWD/files` valid paths for files and templates.

It works for me at the very least.