### PR TITLE
Recognize filenames containing @

### DIFF
--- a/ftplugin/ansible.vim
+++ b/ftplugin/ansible.vim
@@ -2,4 +2,5 @@
 if exists('+regexpengine') && ('&regexpengine' == 0)
   setlocal regexpengine=1
 endif
+set isfname+=@-@
 set path+=./../templates,./../files,templates,files


### PR DESCRIPTION
Description:
Previously, commands like `:normal gf` wouldn't work for files like `myunit@.service.j2`.  See systemd.unit(5).

Rationale:
Flimsy. Users could just as well keep stuff like this in `after/ftplugin`. Just figured, this being Ansible, that messing with systemd units is common enough to warrant this.