### PR TITLE
Use setfiletype to allow overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ This is a vim syntax plugin for Ansible 2.0, it supports YAML playbooks, Jinja2 
 You can also set the filetype to `yaml.ansible`, `*.jinja2`, or `ansible_hosts` if auto-detection does not work (e.g. `:set ft=yaml.ansible` or `:set ft=ruby.jinja2`). **Note**: If you want to detect a custom pattern of your own, you can easily add this in your `.vimrc` using something like this:
 
 ```vim
-au BufRead,BufNewFile */playbooks/*.yml set filetype=yaml.ansible
+au BufRead,BufNewFile */playbooks/*.yml setfiletype yaml.ansible
+```
+
+For some files Ansible lets you choose one of many formats. For example the [documentation](http://docs.ansible.com/ansible/latest/intro_inventory.html#inventory) shows both INI-like and YAML examples of inventory files. This plugin chooses sensible defaults and allows you to override these in your own settings. To continue the inventory file example, the default is `ansible_hosts` and you can override this with something like:
+
+```vim
+au BufNewFile,BufRead hosts setfiletype yaml.ansible
 ```
 
 This plugin should be quite reliable, as it sources the original formats and simply modifies the highlights as appropriate. This also enables a focus on simplicity and configurability instead of patching bad syntax detection.

--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -18,7 +18,7 @@ function! s:setupTemplate()
     for syntax_name in items(g:ansible_template_syntaxes)
       let s:syntax_string = '\v/'.syntax_name[0]
       if filepath =~ s:syntax_string
-        execute 'set ft='.syntax_name[1].'.jinja2'
+        execute 'setfiletype '.syntax_name[1].'.jinja2'
         return
       endif
     endfor
@@ -26,6 +26,6 @@ function! s:setupTemplate()
   set ft=jinja2
 endfunction
 
-au BufNewFile,BufRead * if s:isAnsible() | set ft=yaml.ansible | en
+au BufNewFile,BufRead * if s:isAnsible() | setfiletype yaml.ansible | en
 au BufNewFile,BufRead *.j2 call s:setupTemplate()
-au BufNewFile,BufRead hosts set ft=ansible_hosts
+au BufNewFile,BufRead hosts setfiletype ansible_hosts


### PR DESCRIPTION
Ansible users can choose which syntax to use for files. For example
a user could write a static inventory file - hosts - in INI or YAML
syntax [1].

`:help setfiletype` explains that `setfiletype` will:

    Set the 'filetype' option to {filetype}, but only if not done yet

This allows the user to write their own ftdetect autocommands to choose
a different file type from the default.

Without this change ftdetect auto commands from this package are read
much later in vim's startup process and therefore take precedence
over the user's own. Without this change, this behaviour is difficult to
work around, for example it is very difficult to write ftdetect
autocommands that set the hosts file syntax to YAML.

[1] http://docs.ansible.com/ansible/latest/intro_inventory.html#inventory