### PR TITLE
Add python3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use your favorite plugin manager, or try [vim-plug](https://github.com/junegunn/
 **vim-plug:** `Plug 'pearofducks/ansible-vim'`
 
 **vim-plug with post-update hook:** `Plug 'pearofducks/ansible-vim', { 'do':
-'cd ./UltiSnips; python2 generate.py' }`
+'cd ./UltiSnips; ./generate.py' }`
 
 *Note: `generate.py` requires Ansible 2.4 or later.*
 

--- a/UltiSnips/README.md
+++ b/UltiSnips/README.md
@@ -28,7 +28,6 @@ For your reference, we list them here and you can find them under `/ansible/repo
 For Developers
 --------------
 * `pip install ansible` first
-* python **2** only, because Ansible currently doesn't offically support Python 3.
 
 Thanks
 ------

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -24,10 +24,11 @@ def get_documents():
 def to_snippet(document):
     snippet = []
     if 'options' in document:
+        options = document['options'].items()
         if args.sort:
-            options = sorted(document['options'].items(), key=lambda x: x[1].get('required') or x[0])
-        else:
-            options = sorted(document['options'].items(), key=lambda x: x[1].get('required'), reverse=True)
+            options = sorted(options, key=lambda x: x[0])
+
+        options = sorted(options, key=lambda x: x[1].get('required', False), reverse=True)
 
         for index, (name, option) in enumerate(options, 1):
             if 'choices' in option:
@@ -55,9 +56,9 @@ def to_snippet(document):
             else:
                 snippet.append('\t%s%s${%d:%s}' % (name, delim, index, value))
 
-        # insert a line to seperate required/non-required field
+        # insert a line to seperate required/non-required fields
         for index, (_, option) in enumerate(options):
-            if option.get("required", False) is False:
+            if not option.get("required"):
                 if index != 0:
                     snippet.insert(index, '')
                 break
@@ -100,5 +101,9 @@ if __name__ == "__main__":
         for document in get_documents():
             if 'deprecated' in document:
                 continue
-            f.write(to_snippet(document).encode('utf-8'))
+            snippet = to_snippet(document)
+            if not isinstance(snippet, str):
+                # python2 compatibility
+                snippet = snippet.encode('utf-8')
+            f.write(snippet)
             f.write("\n\n")


### PR DESCRIPTION
As python3 is the future and some distributions already use python3 for Ansible (namely Archlinux). This pull request adds python3 support for snippets generation. Needless to say, python2 still works. 

As a bonus, it's much faster under python3:
```
(tmp) [.../ansible-vim/UltiSnips] ( master *=)$ time python2 ./generate.py --sort

real	0m40.615s
user	0m40.244s
sys	0m0.128s
Time: 0m41s
(tmp) [.../ansible-vim/UltiSnips] (master *=)$ time python3 ./generate.py --sort

real	0m6.227s
user	0m6.062s
sys	0m0.146s
Time: 0m06s
```
