### PR TITLE
Make ansible_yaml_filetype_name customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Accepts a dictionary in the form of `'regex-for-file': 'filetype'`.
 
 All files ending in `*.j2` that aren't matched will simply get the `jinja2` filetype.
 
+#### g:ansible_yaml_filetype_name
+`let g:ansible_yaml_filetype_name = 'yaml.ansible'`
+
+Accepts a string which will match the detected filetype for ansible yaml files.
+Useful in conjunction with ctags and tagbar, which expect `ansible.yaml`
+instead of `yaml.ansible`
+
 ## bugs, suggestions/requests, & contributions
 
 ##### bugs

--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -26,6 +26,13 @@ function! s:setupTemplate()
   set ft=jinja2
 endfunction
 
-au BufNewFile,BufRead * if s:isAnsible() | set ft=yaml.ansible | en
-au BufNewFile,BufRead *.j2 call s:setupTemplate()
-au BufNewFile,BufRead hosts set ft=ansible_hosts
+if !exists('g:ansible_yaml_filetype_name')
+  let g:ansible_yaml_filetype_name = 'yaml.ansible'
+endif
+
+augroup SetupAnsible
+  au!
+  au BufNewFile,BufRead * if s:isAnsible() | execute 'set ft='.g:ansible_yaml_filetype_name | en
+  au BufNewFile,BufRead *.j2 call s:setupTemplate()
+  au BufNewFile,BufRead hosts set ft=ansible_hosts
+augroup END


### PR DESCRIPTION
Introduce variable `g:ansible_yaml_filetype_name = 'yaml.ansible'`

Accepts a string which will match the detected filetype for ansible yaml files.
Useful in conjunction with ctags and tagbar, which expect `ansible.yaml` instead of `yaml.ansible`