### PR TITLE
Fix comments when breaking lines or opening lines.

### DIFF
--- a/indent/ansible.vim
+++ b/indent/ansible.vim
@@ -8,7 +8,7 @@ setlocal expandtab
 setlocal softtabstop=2
 setlocal shiftwidth=2
 setlocal commentstring=#%s
-setlocal formatoptions=cl
+setlocal formatoptions+=cl
 " c -> wrap long comments, including #
 " l -> do not wrap long lines
 


### PR DESCRIPTION
Setting `formatoptions` overrides the defaults, change to adding to
existing setting.

This should fix #66