### PR TITLE
Add au ftdetects in augroups with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ You can also set the filetype to `yaml.ansible`, `*.jinja2`, or `ansible_hosts` 
 au BufRead,BufNewFile */playbooks/*.yml set filetype=yaml.ansible
 ```
 
+If you want to override the default file type detection you can easily do this in your `.vimrc`. For example if you use YAML syntax for `hosts` include something like this:
+
+```vim
+augroup ansible_vim_fthosts
+  autocmd!
+  autocmd BufNewFile,BufRead hosts setfiletype yaml.ansible
+augroup END
+```
+
 This plugin should be quite reliable, as it sources the original formats and simply modifies the highlights as appropriate. This also enables a focus on simplicity and configurability instead of patching bad syntax detection.
 
 ##### examples (with [solarized](https://github.com/altercation/vim-colors-solarized) colorscheme)

--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -26,6 +26,15 @@ function! s:setupTemplate()
   set ft=jinja2
 endfunction
 
-au BufNewFile,BufRead * if s:isAnsible() | set ft=yaml.ansible | en
-au BufNewFile,BufRead *.j2 call s:setupTemplate()
-au BufNewFile,BufRead hosts set ft=ansible_hosts
+augroup ansible_vim_ftyaml_ansible
+    au!
+    au BufNewFile,BufRead * if s:isAnsible() | set ft=yaml.ansible | en
+augroup END
+augroup ansible_vim_ftjinja2
+    au!
+    au BufNewFile,BufRead *.j2 call s:setupTemplate()
+augroup END
+augroup ansible_vim_fthosts
+    au!
+    au BufNewFile,BufRead hosts set ft=ansible_hosts
+augroup END


### PR DESCRIPTION
This is just https://github.com/pearofducks/ansible-vim/pull/57  with an example as requested in the discussion.

Example tested on Debian 9 stretch following the approach in the discussion of https://github.com/pearofducks/ansible-vim/pull/54:

```sh
$ head -n 1 /etc/os-release
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
$ vim --version | head -n 1
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Sep 30 2017 18:21:38)
$ curl -sfLo ~/.vim/autoload/plug.vim --create-dirs \
    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
$ cat > ~/.vim/vimrc <<EOF
set nocp
call plug#begin('~/.vim/plugged')
Plug 'hurricanehrndz/ansible-vim', { 'branch': 'ft-augroup_ftdetect' }
call plug#end()
filetype plugin indent on
syntax on
set ai
set si
augroup ansible_vim_fthosts
  autocmd!
  autocmd BufNewFile,BufRead hosts setfiletype yaml.ansible
augroup END
EOF
$ vim -c ":PlugInstall|qall"
$ vim hosts -c ':echom &ft'
```

This covers the use case behind #54.