### PR TITLE
Add default to highlight links in ansible_hosts.vim

### DIFF
--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -60,7 +60,7 @@ fun! s:attribute_highlight(attributes)
   elseif a:attributes =~ 'd'
     highlight link ansible_attributes Comment
   else
-    highlight link ansible_attributes Structure
+    highlight default link ansible_attributes Structure
   endif
 endfun
 
@@ -75,12 +75,12 @@ if exists("g:ansible_name_highlight")
   if g:ansible_name_highlight =~ 'd'
     highlight link ansible_name Comment
   else
-    highlight link ansible_name Underlined
+    highlight default link ansible_name Underlined
   endif
 endif
 
 execute 'syn keyword ansible_debug_keywords debug containedin='.s:yamlKey.' contained'
-highlight link ansible_debug_keywords Debug
+highlight default link ansible_debug_keywords Debug
 
 if exists("g:ansible_extra_keywords_highlight")
   execute 'syn keyword ansible_extra_special_keywords register always_run changed_when failed_when no_log args vars delegate_to ignore_errors containedin='.s:yamlKey.' contained'
@@ -91,14 +91,14 @@ execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks 
 if exists("g:ansible_normal_keywords_highlight")
   execute 'highlight link ansible_normal_keywords '.g:ansible_normal_keywords_highlight
 else
-  highlight link ansible_normal_keywords Statement
+  highlight default link ansible_normal_keywords Statement
 endif
 
 execute 'syn match ansible_with_keywords "\vwith_.+" containedin='.s:yamlKey.' contained'
 if exists("g:ansible_with_keywords_highlight")
   execute 'highlight link ansible_with_keywords '.g:ansible_with_keywords_highlight
 else
-  highlight link ansible_with_keywords Statement
+  highlight default link ansible_with_keywords Statement
 endif
 
 let b:current_syntax = "ansible"

--- a/syntax/ansible_hosts.vim
+++ b/syntax/ansible_hosts.vim
@@ -14,11 +14,11 @@ syn region hostsHeader        start="\v^\s*\[" end="\v\]"
 syn keyword hostsHeaderSpecials children vars containedin=hostsHeader contained
 syn match  hostsComment       "\v^[#;].*$"
 
-highlight link hostsFirstWord        Label
-highlight link hostsHeader           Define
-highlight link hostsComment          Comment
-highlight link hostsHeaderSpecials   Identifier
-highlight link hostsAttributes       Structure
+highlight default link hostsFirstWord        Label
+highlight default link hostsHeader           Define
+highlight default link hostsComment          Comment
+highlight default link hostsHeaderSpecials   Identifier
+highlight default link hostsAttributes       Structure
 
 if exists("g:ansible_attribute_highlight")
   if g:ansible_attribute_highlight =~ 'n'


### PR DESCRIPTION
Adding default causes the link to be ignored if there is already a link in place for the group. This would allow users/colorscheme owners to override the links set in syntax/ansible_hosts.vim.

See :hi-link for more info.

Would resolve #81.