### PR TITLE
Remove regexpengine workaround

### DIFF
--- a/ftplugin/ansible.vim
+++ b/ftplugin/ansible.vim
@@ -1,6 +1,2 @@
-" Slow yaml highlighting workaround
-if exists('+regexpengine') && ('&regexpengine' == 0)
-  setlocal regexpengine=1
-endif
 set isfname+=@-@
 set path+=./../templates,./../files,templates,files


### PR DESCRIPTION
I have removed regexpengine workaround.
Because, regexpengine option is global option.

It should not be changed by plugin.

```vim
						*'regexpengine'* *'re'*
'regexpengine' 're'	number	(default 0)
			global
	This selects the default regexp engine. |two-engines|
	The possible values are:
		0	automatic selection
		1	old engine
		2	NFA engine
	Note that when using the NFA engine and the pattern contains something
	that is not supported the pattern will not match.  This is only useful
	for debugging the regexp engine.
	Using automatic selection enables Vim to switch the engine, if the
	default engine becomes too costly.  E.g., when the NFA engine uses too
	many states.  This should prevent Vim from hanging on a combination of
	a complex pattern with long text.
```