### PR TITLE
Snippet fix

### DIFF
--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -67,7 +67,7 @@ def to_snippet(document):
         snippet.insert(0, '%s:' % (document['module']))
     else:
         snippet.insert(0, '%s:%s' % (document['module'], ' >' if len(snippet) else ''))
-    snippet.insert(0, 'snippet %s "%s" b' % (document['module'], document['short_description']))
+    snippet.insert(0, "snippet %s '%s' b" % (document['module'], document['short_description']))
     snippet.append('')
     snippet.append('endsnippet')
     return "\n".join(snippet)

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -67,7 +67,7 @@ def to_snippet(document):
         snippet.insert(0, '%s:' % (document['module']))
     else:
         snippet.insert(0, '%s:%s' % (document['module'], ' >' if len(snippet) else ''))
-    snippet.insert(0, "snippet %s '%s' b" % (document['module'], document['short_description']))
+    snippet.insert(0, 'snippet %s "%s" b' % (document['module'], document['short_description'].replace('"', '')))
     snippet.append('')
     snippet.append('endsnippet')
     return "\n".join(snippet)


### PR DESCRIPTION
Certain descriptions in Ansible > 2.9 have quotes. This breaks the snippets generation, so for now we remove any quotes found in descriptions.