### PR TITLE
README.md: Point to new AUR packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Use your favorite plugin manager, or try [vim-plug](https://github.com/junegunn/
 
 **pathogen:** `git clone https://github.com/pearofducks/ansible-vim ~/.vim/bundle/ansible-vim`
 
-**Arch Linux:** Package [ansible-vim-git](https://aur.archlinux.org/packages/ansible-vim-git/) available on AUR
+**Arch Linux:** Packages [vim-ansible](https://aur.archlinux.org/packages/vim-ansible/), [vim-ansible-git](https://aur.archlinux.org/packages/vim-ansible-git/)
+are available on AUR.
 
 ## options
 


### PR DESCRIPTION
To go along with the (de facto) packaging standard of naming vim plugins `^vim-.*` I have created the packages `vim-ansible` and `vim-ansible-git`. Requested a merge of `ansible-vim-git` into `vim-ansible-git` as well. Let me know if that's ok for you.