### PR TITLE
Add Ansible Galaxy config file

### DIFF
--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -3,7 +3,7 @@ function! s:isAnsible()
   let filename = expand("%:t")
   if filepath =~ '\v/(tasks|roles|handlers)/.*\.ya?ml$' | return 1 | en
   if filepath =~ '\v/(group|host)_vars/' | return 1 | en
-  if filename =~ '\v(playbook|site|main|local)\.ya?ml$' | return 1 | en
+  if filename =~ '\v(playbook|site|main|local|requirements)\.ya?ml$' | return 1 | en
 
   let shebang = getline(1)
   if shebang =~# '^#!.*/bin/env\s\+ansible-playbook\>' | return 1 | en


### PR DESCRIPTION
Ansible Galaxy's dependency file is named requirements.yaml, as per:
https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#install-multiple-collections-with-a-requirements-file