### PR TITLE
add 'loop' to highlighted keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Accepts any syntax group-name from `:help E669` - e.g. _Comment_, _Constant_, an
 
 *Note:* Defaults to 'Statement' when not set.
 
-This option changes the highlight of all `with_.+` keywords in playbooks.
+This option changes the highlight of all `with_.+` keywords and `loop` in playbooks.
 
 ##### g:ansible_template_syntaxes
 `let g:ansible_template_syntaxes = { '*.rb.j2': 'ruby' }`

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -87,7 +87,7 @@ if exists("g:ansible_extra_keywords_highlight")
   highlight link ansible_extra_special_keywords Statement
 endif
 
-execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks until retries delay when only_if become become_user block rescue always notify loop containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks until retries delay when only_if become become_user block rescue always notify containedin='.s:yamlKey.' contained'
 if exists("g:ansible_normal_keywords_highlight")
   execute 'highlight link ansible_normal_keywords '.g:ansible_normal_keywords_highlight
 else
@@ -95,6 +95,13 @@ else
 endif
 
 execute 'syn match ansible_with_keywords "\vwith_.+" containedin='.s:yamlKey.' contained'
+if exists("g:ansible_with_keywords_highlight")
+  execute 'highlight link ansible_with_keywords '.g:ansible_with_keywords_highlight
+else
+  highlight default link ansible_with_keywords Statement
+endif
+
+execute 'syn keyword ansible_with_keywords loop containedin='.s:yamlKey.' contained'
 if exists("g:ansible_with_keywords_highlight")
   execute 'highlight link ansible_with_keywords '.g:ansible_with_keywords_highlight
 else

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -87,7 +87,7 @@ if exists("g:ansible_extra_keywords_highlight")
   highlight link ansible_extra_special_keywords Statement
 endif
 
-execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks until retries delay when only_if become become_user block rescue always notify containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks until retries delay when only_if become become_user block rescue always notify loop containedin='.s:yamlKey.' contained'
 if exists("g:ansible_normal_keywords_highlight")
   execute 'highlight link ansible_normal_keywords '.g:ansible_normal_keywords_highlight
 else


### PR DESCRIPTION
Just add highlight for the keyword `loop` which can be used instead of `with_<lookup> since ansible 2.5 : https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html