### PR TITLE
Skip convert_docstring without a module key

### DIFF
--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -246,17 +246,18 @@ def convert_docstring_to_snippet(convert_docstring: Any) -> List[str]:
 
     snippet: List[str] = []
     snippet_options = "b"
-    module_name = convert_docstring["module"]
-    module_short_description = convert_docstring["short_description"]
+    if "module" in convert_docstring.keys():
+        module_name = convert_docstring["module"]
+        module_short_description = convert_docstring["short_description"]
 
-    snippet += [f'snippet {module_name} "{escape_strings(module_short_description)}" {snippet_options}']
-    if args.style == "dictionary":
-        snippet += [f"{module_name}:"]
-    else:
-        snippet += [f"{module_name}:{' >' if convert_docstring.get('options') else ''}"]
-    module_options = module_options_to_snippet_options(convert_docstring.get("options"))
-    snippet += module_options
-    snippet += ["endsnippet"]
+        snippet += [f'snippet {module_name} "{escape_strings(module_short_description)}" {snippet_options}']
+        if args.style == "dictionary":
+            snippet += [f"{module_name}:"]
+        else:
+            snippet += [f"{module_name}:{' >' if convert_docstring.get('options') else ''}"]
+        module_options = module_options_to_snippet_options(convert_docstring.get("options"))
+        snippet += module_options
+        snippet += ["endsnippet"]
 
     return snippet
 


### PR DESCRIPTION
There is a possibility for an AnsibleMapping object to not have the module key when parsing user modules. If that's the case, just skip over it.