### PR TITLE
Remove bash dependency & obsolete commands (Resolves #116)

### DIFF
--- a/UltiSnips/generate.sh
+++ b/UltiSnips/generate.sh
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
+#!/bin/sh
 
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
Since plane sh also can handle this, use that.
Also remove redundant lines for set and IFS commands (lines 2 and 3).