### PR TITLE
use  fully qualified collection name (FQCN) for generated snippets

### DIFF
--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -228,7 +228,7 @@ def module_options_to_snippet_options(module_options: Any) -> List[str]:
     return options
 
 
-def convert_docstring_to_snippet(convert_docstring: Any) -> List[str]:
+def convert_docstring_to_snippet(convert_docstring: Any, collection_name) -> List[str]:
     """Converts data about an Ansible module into an UltiSnips snippet string
 
     Parameters
@@ -252,9 +252,9 @@ def convert_docstring_to_snippet(convert_docstring: Any) -> List[str]:
 
         snippet += [f'snippet {module_name} "{escape_strings(module_short_description)}" {snippet_options}']
         if args.style == "dictionary":
-            snippet += [f"ansible.builtin.{module_name}:"]
+            snippet += [f"{collection_name}.{module_name}:"]
         else:
-            snippet += [f"ansible.builtin.{module_name}:{' >' if convert_docstring.get('options') else ''}"]
+            snippet += [f"{collection_name}.{module_name}:{' >' if convert_docstring.get('options') else ''}"]
         module_options = module_options_to_snippet_options(convert_docstring.get("options"))
         snippet += module_options
         snippet += ["endsnippet"]

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -319,6 +319,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
 
+    if version.parse(ANSIBLE_VERSION) < version.parse("2.10"):
+        print(f"ansible version {ANSIBLE_VERSION} doesn't support FQCN")
+        print("generated snippets will only use the module name e.g. 'yum' instead of 'ansible.builtin.yum'")
+    else:
+        print(f"ansible version {ANSIBLE_VERSION} supports using FQCN")
+        print("Generated snippets will use FQCN e.g. 'ansible.builtin.yum' instead of 'yum'")
+        print("Still, you only need to type 'yum' to trigger the snippet")
+
     modules_docstrings = []
 
     builtin_modules_paths = get_files_builtin()

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -318,29 +318,28 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+
+    modules_docstrings = []
+
     builtin_modules_paths = get_files_builtin()
-    builtin_modules_docstrings = []
     for f in builtin_modules_paths:
         docstring_builtin = get_module_docstring(f)
-        if docstring_builtin and docstring_builtin not in builtin_modules_docstrings:
+        if docstring_builtin and docstring_builtin not in modules_docstrings:
             docstring_builtin['collection_name'] = "ansible.builtin"
-            builtin_modules_docstrings.append(docstring_builtin)
-    all_docstrings = builtin_modules_docstrings
+            modules_docstrings.append(docstring_builtin)
 
     if args.user:
         user_modules_paths = get_files_user()
-        user_modules_docstrings = []
         for f in user_modules_paths:
             docstring_user = get_module_docstring(f)
-            if docstring_user and docstring_user not in user_modules_docstrings:
+            if docstring_user and docstring_user not in modules_docstrings:
                 collection_name = get_collection_name(f)
                 docstring_user['collection_name'] = collection_name
-                user_modules_docstrings.append(docstring_user)
-        all_docstrings += user_modules_docstrings
+                modules_docstrings.append(docstring_user)
 
     with open(args.output, "w") as f:
         f.writelines(f"{header}\n" for header in HEADER)
-        for docstring in all_docstrings:
+        for docstring in modules_docstrings:
             f.writelines(
                 f"{line}\n" for line in convert_docstring_to_snippet(docstring, docstring.get("collection_name"))
             )

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -312,7 +312,7 @@ if __name__ == "__main__":
         all_modules_paths = get_files(include_user=True)
         user_modules_paths = []
         for f in all_modules_paths:
-            if 'ansible_collections' in f:
+            if 'plugins/modules/' in f:
                 user_modules_paths.append(f)
 
         user_modules_docstrings = []

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -32,16 +32,24 @@ def get_files(include_user: bool = False) -> List[str]:
 
     file_names: List[str] = []
     for root, dirs, files in os.walk(os.path.dirname(ansible.modules.__file__)):
+        files_without_symlinks = []
+        for f in files:
+            if not os.path.islink(os.path.join(root, f)):
+                files_without_symlinks.append(f)
         file_names += [
             f"{root}/{file_name}"
-            for file_name in files
+            for file_name in files_without_symlinks
             if file_name.endswith(".py") and not file_name.startswith("__init__")
         ]
     if include_user:
         for root, dirs, files in os.walk(os.path.expanduser('~/.ansible/collections/ansible_collections/')):
+            files_without_symlinks = []
+            for f in files:
+                if not os.path.islink(os.path.join(root, f)):
+                    files_without_symlinks.append(f)
             file_names += [
                 f"{root}/{file_name}"
-                for file_name in files
+                for file_name in files_without_symlinks
                 if file_name.endswith(".py") and not file_name.startswith("__init__")
             ]
 

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -309,12 +309,7 @@ if __name__ == "__main__":
     all_docstrings = builtin_modules_docstrings
 
     if args.user:
-        all_modules_paths = get_files(include_user=True)
-        user_modules_paths = []
-        for f in all_modules_paths:
-            if 'ansible_collections' in f:
-                user_modules_paths.append(f)
-
+        user_modules_paths = get_files(include_user=True)
         user_modules_docstrings = []
         for f in user_modules_paths:
             docstring_user = get_module_docstring(f)

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -252,9 +252,9 @@ def convert_docstring_to_snippet(convert_docstring: Any) -> List[str]:
 
         snippet += [f'snippet {module_name} "{escape_strings(module_short_description)}" {snippet_options}']
         if args.style == "dictionary":
-            snippet += [f"{module_name}:"]
+            snippet += [f"ansible.builtin.{module_name}:"]
         else:
-            snippet += [f"{module_name}:{' >' if convert_docstring.get('options') else ''}"]
+            snippet += [f"ansible.builtin.{module_name}:{' >' if convert_docstring.get('options') else ''}"]
         module_options = module_options_to_snippet_options(convert_docstring.get("options"))
         snippet += module_options
         snippet += ["endsnippet"]

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -312,11 +312,12 @@ if __name__ == "__main__":
         user_modules_paths = get_files(include_user=True)
         user_modules_docstrings = []
         for f in user_modules_paths:
-            docstring_user = get_module_docstring(f)
-            if docstring_user and docstring_user not in user_modules_docstrings:
-                collection_name = get_collection_name(f)
-                docstring_user['collection_name'] = collection_name
-                user_modules_docstrings.append(docstring_user)
+            if "plugins/modules/" in f:
+                docstring_user = get_module_docstring(f)
+                if docstring_user and docstring_user not in user_modules_docstrings:
+                    collection_name = get_collection_name(f)
+                    docstring_user['collection_name'] = collection_name
+                    user_modules_docstrings.append(docstring_user)
 
         all_docstrings += user_modules_docstrings
 

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -284,10 +284,23 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    docstrings = get_docstrings(get_files(include_user=args.user))
+    docstrings_builtin = get_docstrings(get_files(include_user=False))
+
+    if args.user:
+        all_files = get_files(include_user=True)
+        user_files = []
+        for i in all_files:
+            if 'collections' in i:
+                user_files.append(i)
+        docstrings_user = get_docstrings(user_files)
+
     with open(args.output, "w") as f:
         f.writelines(f"{header}\n" for header in HEADER)
-        for docstring in docstrings:
+        for docstring in docstrings_builtin:
             f.writelines(
-                f"{line}\n" for line in convert_docstring_to_snippet(docstring)
+                f"{line}\n" for line in convert_docstring_to_snippet(docstring, "ansible.builtin")
+            )
+        for docstring in docstrings_user:
+            f.writelines(
+                f"{line}\n" for line in convert_docstring_to_snippet(docstring, "just_testing")
             )

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -283,7 +283,7 @@ def convert_docstring_to_snippet(convert_docstring: Any, collection_name) -> Lis
 
     return snippet
 
-def get_collection_name(filepath):
+def get_collection_name(filepath:str) -> str:
     """ Returns the collection name for a full file path """
 
     path_splitted = filepath.split('/')

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -50,7 +50,7 @@ def get_files(include_user: bool = False) -> List[str]:
             file_names += [
                 f"{root}/{file_name}"
                 for file_name in files_without_symlinks
-                if file_name.endswith(".py") and not file_name.startswith("__init__")
+                if file_name.endswith(".py") and not file_name.startswith("__init__") and "plugins/modules" in root
             ]
 
     return sorted(file_names)
@@ -312,7 +312,7 @@ if __name__ == "__main__":
         all_modules_paths = get_files(include_user=True)
         user_modules_paths = []
         for f in all_modules_paths:
-            if 'plugins/modules/' in f:
+            if 'ansible_collections' in f:
                 user_modules_paths.append(f)
 
         user_modules_docstrings = []

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -300,11 +300,16 @@ if __name__ == "__main__":
 
     if args.user:
         all_files = get_files(include_user=True)
-        user_files = []
+        docstrings_user = []
         for i in all_files:
-            if 'collections' in i:
-                user_files.append(i)
-        docstrings_user = get_docstrings(user_files)
+            if 'ansible_collections' in i:
+                collection_name = get_collection_name(i)
+                tmp_list = [i]
+                tmp_docstring_list = []
+                tmp_docstring_list = get_docstrings(tmp_list)
+                if tmp_docstring_list:
+                    tmp_docstring_list[0]['collection_name'] = collection_name
+                    docstrings_user.append(tmp_docstring_list[0])
 
     with open(args.output, "w") as f:
         f.writelines(f"{header}\n" for header in HEADER)
@@ -314,6 +319,7 @@ if __name__ == "__main__":
             )
         if args.user:
             for docstring in docstrings_user:
-                f.writelines(
-                    f"{line}\n" for line in convert_docstring_to_snippet(docstring, "just_testing")
-                )
+                if 'collection_name' in docstring.keys():
+                    f.writelines(
+                        f"{line}\n" for line in convert_docstring_to_snippet(docstring, docstring['collection_name'])
+                    )

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -300,7 +300,8 @@ if __name__ == "__main__":
             f.writelines(
                 f"{line}\n" for line in convert_docstring_to_snippet(docstring, "ansible.builtin")
             )
-        for docstring in docstrings_user:
-            f.writelines(
-                f"{line}\n" for line in convert_docstring_to_snippet(docstring, "just_testing")
-            )
+        if args.user:
+            for docstring in docstrings_user:
+                f.writelines(
+                    f"{line}\n" for line in convert_docstring_to_snippet(docstring, "just_testing")
+                )

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -340,7 +340,7 @@ if __name__ == "__main__":
 
     with open(args.output, "w") as f:
         f.writelines(f"{header}\n" for header in HEADER)
-        for docstring in builtin_modules_docstrings:
+        for docstring in all_docstrings:
             f.writelines(
                 f"{line}\n" for line in convert_docstring_to_snippet(docstring, docstring.get("collection_name"))
             )

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -48,31 +48,26 @@ def get_files(include_user: bool = False) -> List[str]:
     return sorted(file_names)
 
 
-def get_docstrings(file_names: List[str]) -> List[Any]:
-    """Extract and return a list of docstring information from a list of files
+def get_module_docstring(file_path: str) -> Any:
+    """Extract and return docstring information from a module file
 
     Parameters
     ----------
-    file_names: List[str]
-        A list of strings representing file names
+    file_names: file_path[str]
+        string representing module file
 
     Returns
     -------
-    List[Any]
-        A list of AnsibleMapping objects, representing docstring information
+    Any
+        An AnsibleMapping object, representing docstring information
         (in dict form), excluding those that are marked as deprecated.
 
     """
 
-    found_docstrings: List[Any] = []
-    found_docstrings += [
-        get_docstring(file_name, fragment_loader)[0] for file_name in file_names
-    ]
-    return [
-        current_docstring
-        for current_docstring in found_docstrings
-        if current_docstring and not current_docstring.get("deprecated")
-    ]
+    docstring = get_docstring(file_path, fragment_loader)[0]
+
+    if docstring and not docstring.get("deprecated"):
+        return docstring
 
 
 def escape_strings(escapist: str) -> str:

--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -261,6 +261,18 @@ def convert_docstring_to_snippet(convert_docstring: Any, collection_name) -> Lis
 
     return snippet
 
+def get_collection_name(filepath):
+    """ Returns the collection name for a full file path """
+
+    path_splitted = filepath.split('/')
+
+    collection_top_folder_index = path_splitted.index('ansible_collections')
+    collection_namespace = path_splitted[collection_top_folder_index + 1]
+    collection_name = path_splitted[collection_top_folder_index + 2]
+
+    #  print(f"{collection_namespace}.{collection_name}")
+    return f"{collection_namespace}.{collection_name}"
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
in the latest ansible versions it's recommended to use the `fully qualified collection name (FQCN) ` for modules e.g. `ansible.builtin.yum` instead of just `yum` . This is a quick&dirty PoC to include the FQCN in the generated snippets. 

I guess to do it in a cleaner way it would require a bigger refactor of the script. By now I tried to don't modify your existing functions and feed them with lists.

This PoC has a weird problem which I couldn't fix yet. I don't know why when I do `ansible-galaxy collection install openstack.cloud` and I execute the script `generate.py --user` the generated file `ansible.snippets` includes the openstack modules twice. I don't get why. Probably I am doing some stupid mistake.

It would be nice if the collection name could be queried directly using `ansible.utils` or `ansible.plugins` but in a quick search I couldn't find how to do it and I ended up parsing the path in the new function `get_collection_name()` . Do you know if there is any better alternative to get the collection name?

If you are open to merge this I can try to improve it. I wanted to get your opinion about how it should be done before investing more time and do a bigger refactor that maybe you know how to do better.