### PR TITLE
Update keywords in an ansible syntax file

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Accepts any syntax group-name from `:help E669` - e.g. _Comment_, _Constant_, an
 
 *Note:* Defaults to 'Statement' when not set.
 
-This option changes the highlight of all `with_.+` keywords and `loop` in playbooks.
+This option changes the highlight of all `with_.+`, `loop` and `loop_control` keywords in playbooks.
 
 ##### g:ansible_template_syntaxes
 `let g:ansible_template_syntaxes = { '*.rb.j2': 'ruby' }`

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Available flags (this feature is off by default):
 
 *Note:* This option is enabled when set, and disabled when not set.
 
-Highlight the following additional keywords in playbooks: `register always_run changed_when failed_when no_log args vars delegate_to ignore_errors`
+Highlight the following additional keywords: `debugger register always_run changed_when failed_when no_log args vars vars_prompt delegate_to ignore_errors roles tags`
 
-By default we only highlight: `include until retries delay when only_if become become_user block rescue always notify`
+By default we only highlight: `include include_tasks import_tasks include_role import_role import_playbook until retries delay when only_if become become_user become_method become_flags become_pass become_exe block rescue always notify listen`.
 
 ##### g:ansible_normal_keywords_highlight
 `let g:ansible_normal_keywords_highlight = 'Constant'`
@@ -108,7 +108,7 @@ Accepts any syntax group name from `:help E669` - e.g. _Comment_, _Constant_, an
 
 *Note:* Defaults to 'Statement' when not set.
 
-This option change the highlight of the following common keywords in playbooks: `include until retries delay when only_if become become_user block rescue always notify`
+This option change the highlight of the following common keywords: `include include_tasks import_tasks include_role import_role import_playbook until retries delay when only_if become become_user become_method become_flag become_pass become_exe block rescue always notify listen`.
 
 ##### g:ansible_with_keywords_highlight
 `let g:ansible_with_keywords_highlight = 'Constant'`
@@ -117,7 +117,7 @@ Accepts any syntax group-name from `:help E669` - e.g. _Comment_, _Constant_, an
 
 *Note:* Defaults to 'Statement' when not set.
 
-This option changes the highlight of all `with_.+`, `loop` and `loop_control` keywords in playbooks.
+This option changes the highlight of all `with_.+`, `loop` and `loop_control` keywords.
 
 ##### g:ansible_template_syntaxes
 `let g:ansible_template_syntaxes = { '*.rb.j2': 'ruby' }`

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -83,11 +83,11 @@ execute 'syn keyword ansible_debug_keywords debug containedin='.s:yamlKey.' cont
 highlight default link ansible_debug_keywords Debug
 
 if exists("g:ansible_extra_keywords_highlight")
-  execute 'syn keyword ansible_extra_special_keywords register always_run changed_when failed_when no_log args vars delegate_to ignore_errors containedin='.s:yamlKey.' contained'
+  execute 'syn keyword ansible_extra_special_keywords debugger register always_run changed_when failed_when no_log args vars vars_prompt delegate_to ignore_errors roles tags containedin='.s:yamlKey.' contained'
   highlight link ansible_extra_special_keywords Statement
 endif
 
-execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks until retries delay when only_if become become_user block rescue always notify containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks include_role import_role import_playbook until retries delay when only_if become become_user become_method become_flags become_pass become_exe block rescue always notify listen containedin='.s:yamlKey.' contained'
 if exists("g:ansible_normal_keywords_highlight")
   execute 'highlight link ansible_normal_keywords '.g:ansible_normal_keywords_highlight
 else

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -101,7 +101,7 @@ else
   highlight default link ansible_with_keywords Statement
 endif
 
-execute 'syn keyword ansible_with_keywords loop containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_with_keywords loop loop_control containedin='.s:yamlKey.' contained'
 if exists("g:ansible_with_keywords_highlight")
   execute 'highlight link ansible_with_keywords '.g:ansible_with_keywords_highlight
 else


### PR DESCRIPTION
Added new keywords:

**ansible_extra_special_keywords**: debugger, vars_prompt, roles, tags

**ansible_normal_keywords**: include_tasks import_tasks include_role import_role import_playbook, become_method become_flag become_pass become_exe, listen

**ansible_with_keywords**: loop_control

