### PR TITLE
Massive keywords update, added configurable ansible_extra_special_keywords syntax group

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,27 +97,34 @@ Available flags (this feature is off by default):
 
 *Note:* This option is enabled when set, and disabled when not set.
 
-Highlight the following additional keywords: `debugger register always_run changed_when failed_when no_log args vars vars_prompt delegate_to ignore_errors roles tags`
+Highlight the following additional keywords: `become become_exe become_flags become_method become_user become_pass prompt_l10n debugger always_run check_mode diff no_log args tags force_handlers vars vars_files vars_prompt delegate_facts delegate_to any_errors_fatal ignore_errors ignore_unreachable max_fail_percentage connection hosts port remote_user module_defaults environment fact_path gather_facts gather_subset gather_timeout async poll throttle timeout order run_once serial strategy`.
 
-By default we only highlight: `include include_tasks import_tasks include_role import_role import_playbook until retries delay when only_if become become_user become_method become_flags become_pass become_exe block rescue always notify listen`.
+By default we only highlight: `include include_role include_tasks include_vars import_role import_playbook import_tasks when changed_when failed_when block rescue always notify listen register action local_action post_tasks pre_tasks tasks handlers roles collections` and loop keywords `with_.+`, `loop`, `loop_control`, `until`, `retries`, `delay`.
+
+##### g:ansible_extra_keywords_highlight_group
+`let g:ansible_extra_keywords_highlight_group = 'Statement'`
+
+Accepts any syntax group name from `:help E669` - e.g. _Comment_, _Constant_, _Identifier_
+
+*Note:* Defaults to 'Structure' when not set.
 
 ##### g:ansible_normal_keywords_highlight
 `let g:ansible_normal_keywords_highlight = 'Constant'`
 
-Accepts any syntax group name from `:help E669` - e.g. _Comment_, _Constant_, and _Identifier_
+Accepts any syntax group name from `:help E669` - e.g. _Comment_, _Constant_, _Identifier_
 
 *Note:* Defaults to 'Statement' when not set.
 
-This option change the highlight of the following common keywords: `include include_tasks import_tasks include_role import_role import_playbook until retries delay when only_if become become_user become_method become_flag become_pass become_exe block rescue always notify listen`.
+This option change the highlight of the following common keywords: `include include_role include_tasks include_vars import_role import_playbook import_tasks when changed_when failed_when block rescue always notify listen register action local_action post_tasks pre_tasks tasks handlers roles collections`.
 
-##### g:ansible_with_keywords_highlight
-`let g:ansible_with_keywords_highlight = 'Constant'`
+##### g:ansible_loop_keywords_highlight
+`let g:ansible_loop_keywords_highlight = 'Constant'`
 
-Accepts any syntax group-name from `:help E669` - e.g. _Comment_, _Constant_, and _Identifier_
+Accepts any syntax group-name from `:help E669` - e.g. _Comment_, _Constant_, _Identifier_
 
 *Note:* Defaults to 'Statement' when not set.
 
-This option changes the highlight of all `with_.+`, `loop` and `loop_control` keywords.
+This option changes the highlight of all `with_.+`, `loop`, `loop_control`, `until`, `retries` and `delay` keywords.
 
 ##### g:ansible_template_syntaxes
 `let g:ansible_template_syntaxes = { '*.rb.j2': 'ruby' }`

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -87,7 +87,7 @@ if exists("g:ansible_extra_keywords_highlight")
   highlight link ansible_extra_special_keywords Statement
 endif
 
-execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks include_role import_role import_playbook until retries delay when only_if become become_user become_method become_flags become_pass become_exe block rescue always notify listen containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks include_role import_role import_playbook until retries delay when become become_user become_method become_flags become_pass become_exe block rescue always notify listen containedin='.s:yamlKey.' contained'
 if exists("g:ansible_normal_keywords_highlight")
   execute 'highlight link ansible_normal_keywords '.g:ansible_normal_keywords_highlight
 else

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -83,18 +83,32 @@ execute 'syn keyword ansible_debug_keywords debug containedin='.s:yamlKey.' cont
 highlight default link ansible_debug_keywords Debug
 
 if exists("g:ansible_extra_keywords_highlight")
-  execute 'syn keyword ansible_extra_special_keywords debugger register always_run changed_when failed_when no_log args vars vars_prompt delegate_to ignore_errors roles tags containedin='.s:yamlKey.' contained'
+  execute 'syn keyword ansible_extra_special_keywords
+              \ become become_exe become_flags become_method become_user become_pass prompt_l10n
+              \ debugger always_run check_mode diff no_log args tags force_handlers
+              \ vars vars_files vars_prompt delegate_facts delegate_to
+              \ any_errors_fatal ignore_errors ignore_unreachable max_fail_percentage
+              \ connection hosts port remote_user module_defaults
+              \ environment fact_path gather_facts gather_subset gather_timeout
+              \ async poll throttle timeout order run_once serial strategy
+              \ containedin='.s:yamlKey.' contained'
   highlight link ansible_extra_special_keywords Statement
 endif
 
-execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks include_role import_role import_playbook when become become_user become_method become_flags become_pass become_exe block rescue always notify listen containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_normal_keywords
+            \ include include_role include_tasks include_vars import_role import_playbook import_tasks
+            \ when changed_when failed_when block rescue always notify listen register
+            \ action local_action post_tasks pre_tasks tasks handlers roles collections
+            \ containedin='.s:yamlKey.' contained'
 if exists("g:ansible_normal_keywords_highlight")
   execute 'highlight link ansible_normal_keywords '.g:ansible_normal_keywords_highlight
 else
   highlight default link ansible_normal_keywords Statement
 endif
 
-execute 'syn keyword ansible_loop_keywords loop loop_control until retries delay containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_loop_keywords
+            \ loop loop_control until retries delay
+            \ containedin='.s:yamlKey.' contained'
 execute 'syn match ansible_loop_keywords "\vwith_.+" containedin='.s:yamlKey.' contained'
 if exists("g:ansible_loop_keywords_highlight")
   execute 'highlight link ansible_loop_keywords '.g:ansible_loop_keywords_highlight

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -94,18 +94,12 @@ else
   highlight default link ansible_normal_keywords Statement
 endif
 
-execute 'syn match ansible_with_keywords "\vwith_.+" containedin='.s:yamlKey.' contained'
-if exists("g:ansible_with_keywords_highlight")
-  execute 'highlight link ansible_with_keywords '.g:ansible_with_keywords_highlight
+execute 'syn keyword ansible_loop_keywords loop loop_control containedin='.s:yamlKey.' contained'
+execute 'syn match ansible_loop_keywords "\vwith_.+" containedin='.s:yamlKey.' contained'
+if exists("g:ansible_loop_keywords_highlight")
+  execute 'highlight link ansible_loop_keywords '.g:ansible_loop_keywords_highlight
 else
-  highlight default link ansible_with_keywords Statement
-endif
-
-execute 'syn keyword ansible_with_keywords loop loop_control containedin='.s:yamlKey.' contained'
-if exists("g:ansible_with_keywords_highlight")
-  execute 'highlight link ansible_with_keywords '.g:ansible_with_keywords_highlight
-else
-  highlight default link ansible_with_keywords Statement
+  highlight default link ansible_loop_keywords Statement
 endif
 
 let b:current_syntax = "ansible"

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -87,14 +87,14 @@ if exists("g:ansible_extra_keywords_highlight")
   highlight link ansible_extra_special_keywords Statement
 endif
 
-execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks include_role import_role import_playbook until retries delay when become become_user become_method become_flags become_pass become_exe block rescue always notify listen containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_normal_keywords include include_tasks import_tasks include_role import_role import_playbook when become become_user become_method become_flags become_pass become_exe block rescue always notify listen containedin='.s:yamlKey.' contained'
 if exists("g:ansible_normal_keywords_highlight")
   execute 'highlight link ansible_normal_keywords '.g:ansible_normal_keywords_highlight
 else
   highlight default link ansible_normal_keywords Statement
 endif
 
-execute 'syn keyword ansible_loop_keywords loop loop_control containedin='.s:yamlKey.' contained'
+execute 'syn keyword ansible_loop_keywords loop loop_control until retries delay containedin='.s:yamlKey.' contained'
 execute 'syn match ansible_loop_keywords "\vwith_.+" containedin='.s:yamlKey.' contained'
 if exists("g:ansible_loop_keywords_highlight")
   execute 'highlight link ansible_loop_keywords '.g:ansible_loop_keywords_highlight

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -95,7 +95,7 @@ if exists("g:ansible_extra_keywords_highlight")
   if exists("g:ansible_extra_keywords_highlight_group")
     execute 'highlight link ansible_extra_special_keywords '.g:ansible_extra_keywords_highlight_group
   else
-    highlight link ansible_extra_special_keywords Statement
+    highlight link ansible_extra_special_keywords Structure
   endif
 endif
 

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -98,6 +98,9 @@ execute 'syn keyword ansible_loop_keywords loop loop_control until retries delay
 execute 'syn match ansible_loop_keywords "\vwith_.+" containedin='.s:yamlKey.' contained'
 if exists("g:ansible_loop_keywords_highlight")
   execute 'highlight link ansible_loop_keywords '.g:ansible_loop_keywords_highlight
+" backward compatibility: ansible_with_keywords_highlight replaced by ansible_loop_keywords_highlight
+elseif exists("g:ansible_with_keywords_highlight")
+  execute 'highlight link ansible_loop_keywords '.g:ansible_with_keywords_highlight
 else
   highlight default link ansible_loop_keywords Statement
 endif

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -92,7 +92,11 @@ if exists("g:ansible_extra_keywords_highlight")
               \ environment fact_path gather_facts gather_subset gather_timeout
               \ async poll throttle timeout order run_once serial strategy
               \ containedin='.s:yamlKey.' contained'
-  highlight link ansible_extra_special_keywords Statement
+  if exists("g:ansible_extra_keywords_highlight_group")
+    execute 'highlight link ansible_extra_special_keywords '.g:ansible_extra_keywords_highlight_group
+  else
+    highlight link ansible_extra_special_keywords Statement
+  endif
 endif
 
 execute 'syn keyword ansible_normal_keywords


### PR DESCRIPTION
- added almost all Ansible keywords
- removed deprecated 'only_if' keyword
- renamed ansible_with_keywords to ansible_loop_keywords
- added all loop keywords (loop, loop_control, until, retries, delay, with_*) to the ansible_loop_keywords
- added optional ansible_extra_keywords_highlight_group variable to configure ansible_extra_special_keywords syntax group
ansible_extra_keywords_highlight variable remained boolean for backward compatibility
- default systax group for ansible_extra_special_keywords changed to Structure (to differ from ansible_normal_keywords by default)