### PR TITLE
indent: default to the result of GetYAMLIndent; always return the def…

### DIFF
--- a/indent/ansible.vim
+++ b/indent/ansible.vim
@@ -18,6 +18,7 @@ let s:named_module_entry = '\v^\s*-\s*(name|hosts|role):\s*\S' " - name: 'do stu
 let s:dictionary_entry = '\v^\s*[^:-]+:\s*$' " with_items:
 let s:key_value = '\v^\s*[^:-]+:\s*\S' " apt: name=package
 let s:scalar_value = '\v:\s*[>|\|]\s*$' " shell: >
+let s:blank = '\v^\s*$' " line with only spaces
 
 if exists('*GetAnsibleIndent')
   finish
@@ -33,26 +34,29 @@ function GetAnsibleIndent(lnum)
     endif
   endif
   let prevlnum = prevnonblank(a:lnum - 1)
-  let maintain = indent(prevlnum)
-  let increase = maintain + &sw
+  let default = GetYAMLIndent(a:lnum)
+  let increase = indent(prevlnum) + &sw
 
-  let line = getline(prevlnum)
-  if line =~ s:array_entry
-    if line =~ s:named_module_entry
+  let prevline = getline(prevlnum)
+  let line = getline(a:lnum)
+  if line !~ s:blank
+    return default  " we only special case blank lines
+  elseif prevline =~ s:array_entry
+    if prevline =~ s:named_module_entry
       return increase
     else
-      return maintain
+      return default
     endif
-  elseif line =~ s:dictionary_entry
+  elseif prevline =~ s:dictionary_entry
     return increase
-  elseif line =~ s:key_value
-    if line =~ s:scalar_value
+  elseif prevline =~ s:key_value
+    if prevline =~ s:scalar_value
       return increase
     else
-      return maintain
+      return default
     endif
   else
-    return maintain
+    return default
   endif
 endfunction
 


### PR DESCRIPTION
…ault for non-blank lines

Fixes pearofducks/ansible-vim/issues/126

I'm not sure what you do for testing.  I've been using the patched version for the last week and haven't noticed any problems.