### PR TITLE
UltiSnips: add an option to remove options decriptions.

### DIFF
--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -150,7 +150,7 @@ def option_data_to_snippet_completion(option_data: Any) -> str:
             return "false"
 
     # if there is no default and no choices, return the description
-    if not choices and default is None:
+    if not choices and default is None and not args.no_description:
         return f"# {description}"
 
     # if there is a default but no choices return the default as string
@@ -313,6 +313,12 @@ if __name__ == "__main__":
     parser.add_argument(
         '--user',
         help="Include user modules",
+        action="store_true",
+        default=False
+    )
+    parser.add_argument(
+        '--no-description',
+        help="Remove options description",
         action="store_true",
         default=False
     )


### PR DESCRIPTION
This adds the `--no-description` option to `UltiSnips/generate.py` with effect to remove descriptions (that can be lengthy) for module options w/o default or choices.

Before:
```
snippet add_host "Add a host (and alternatively a group) to the ansible-playbook in-memory inventory" b
ansible.builtin.add_host:
	name: ${1:# The hostname/ip of the host to add to the inventory, can include a colon and a port number.}

	groups: ${3:# The groups to add the hostname to.}
endsnippet
```

After:
```
snippet add_host "Add a host (and alternatively a group) to the ansible-playbook in-memory inventory" b
ansible.builtin.add_host:
	name: ${1:}

	groups: ${3:}
endsnippet
```