### PR TITLE
UltiSnips: add an option to comment non-required options.

### DIFF
--- a/UltiSnips/generate.py
+++ b/UltiSnips/generate.py
@@ -220,7 +220,7 @@ def module_options_to_snippet_options(module_options: Any) -> List[str]:
 
     # insert an empty option above the list of non-required options
     for index, (_, option) in enumerate(module_options):
-        if not option.get("required"):
+        if not option.get("required") and not args.comment_non_required:
             if index != 0:
                 module_options.insert(index, (None, None))
             break
@@ -230,14 +230,19 @@ def module_options_to_snippet_options(module_options: Any) -> List[str]:
         if not name and not option_data:
             options += [""]
         else:
+            # set comment character for non-required options
+            if not option_data.get("required") and args.comment_non_required:
+                comment = "#"
+            else:
+                comment = ""
             # the free_form option in some modules are special
             if name == "free_form":
                 options += [
-                    f"\t${{{index}:{name}{delimiter}{option_data_to_snippet_completion(option_data)}}}"
+                    f"\t{comment}${{{index}:{name}{delimiter}{option_data_to_snippet_completion(option_data)}}}"
                 ]
             else:
                 options += [
-                    f"\t{name}{delimiter}${{{index}:{option_data_to_snippet_completion(option_data)}}}"
+                    f"\t{comment}{name}{delimiter}${{{index}:{option_data_to_snippet_completion(option_data)}}}"
                 ]
 
     return options
@@ -313,6 +318,12 @@ if __name__ == "__main__":
     parser.add_argument(
         '--user',
         help="Include user modules",
+        action="store_true",
+        default=False
+    )
+    parser.add_argument(
+        '--comment-non-required',
+        help="Comment non-required options",
         action="store_true",
         default=False
     )


### PR DESCRIPTION
This adds the `--comment-non-required` option to `UltiSnips/generate.py` with effect to:

1. suppress the blank line between required and non-required options
2. prefix a comment ('#') symbol before non-required options.

Before:
```
snippet add_host "Add a host (and alternatively a group) to the ansible-playbook in-memory inventory" b
ansible.builtin.add_host:
	name: ${1:# The hostname/ip of the host to add to the inventory, can include a colon and a port number.}

	groups: ${3:# The groups to add the hostname to.}
endsnippet
```

After:
```
snippet add_host "Add a host (and alternatively a group) to the ansible-playbook in-memory inventory" b
ansible.builtin.add_host:
	name: ${1:# The hostname/ip of the host to add to the inventory, can include a colon and a port number.}
	#groups: ${2:# The groups to add the hostname to.}
endsnippet
```

This is useful as all unused (left commented-out) non-required options can then be quickly removed in Vim with the following sequence:
```vim
{ V } " visually select the current pagraph = inserted module snippet
:'<,'>g/^\s\+#/d " command to delete all lines beginning with spaces/tabs and the comment symbol in current visual selection
```