### PR TITLE
fix: improve name key match

### DIFF
--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -71,7 +71,7 @@ else
 endif
 
 if exists("g:ansible_name_highlight")
-  execute 'syn keyword ansible_name name containedin='.s:yamlKey.' contained'
+  execute 'syn match ansible_name "^\s*-\s\+name:"'
   if g:ansible_name_highlight =~ 'd'
     highlight link ansible_name Comment
   else


### PR DESCRIPTION
This refines the matching for the name key to only target instances where it's an item in a list. This change significantly reduces the likelihood of false positives.

Related Issue: #109 

The highlighting now looks like this:
![image](https://github.com/pearofducks/ansible-vim/assets/455556/788150e0-cd86-446b-8d2d-efb13f65bbab)

However, there are still some edge cases to be aware of:
![image](https://github.com/pearofducks/ansible-vim/assets/455556/a2228912-afdf-43c1-91d8-aec4138e495b)

Which you could work around like so: 
![image](https://github.com/pearofducks/ansible-vim/assets/455556/eea6ea4d-94db-4aff-bbb5-f07fc3088e06)


