### PR TITLE
fix: match full file name in ftdetect

### DIFF
--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -3,7 +3,7 @@ function! s:isAnsible()
   let filename = expand("%:t")
   if filepath =~ '\v/(tasks|roles|handlers)/.*\.ya?ml$' | return 1 | en
   if filepath =~ '\v/(group|host)_vars/' | return 1 | en
-  let s:ftdetect_filename_regex = '\v(playbook|site|main|local|requirements)\.ya?ml$'
+  let s:ftdetect_filename_regex = '\v^(playbook|site|main|local|requirements)\.ya?ml$'
   if exists("g:ansible_ftdetect_filename_regex")
     let s:ftdetect_filename_regex = g:ansible_ftdetect_filename_regex
   endif


### PR DESCRIPTION
This fixes the issue when files like `foo-main.yaml` are incorrectly recognized as ansible files.