### PR TITLE
fix: exclude /etc/hosts from filetype detection

### DIFF
--- a/ftdetect/ansible.vim
+++ b/ftdetect/ansible.vim
@@ -45,5 +45,6 @@ augroup ansible_vim_ftjinja2
 augroup END
 augroup ansible_vim_fthosts
     au!
-    au BufNewFile,BufRead hosts set ft=ansible_hosts
+    au BufNewFile,BufRead hosts
+      \ if expand("%:p") !=# "/etc/hosts" | set ft=ansible_hosts | en
 augroup END


### PR DESCRIPTION
This plugin sets `ft=ansible_hosts` for any file named `hosts`, including `/etc/hosts`.