### PR TITLE
Feature: Use ansible-doc as keywordprg

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ Accepts any syntax group-name from `:help E669` - e.g. _Comment_, _Constant_, _I
 
 This option changes the highlight of all `with_.+`, `loop`, `loop_control`, `until`, `retries` and `delay` keywords.
 
-##### g:ansible_builtin_modules_highlight
+##### g:ansible_builtin_modules_highlight (vim9script feature)
+
+(Does not exist in `neovim`.)
+
 `let g:ansible_builtin_modules_highlight = 'Constant'`
 
 Accepts any syntax group-name from `:help E669` - e.g. _Comment_, _Constant_, _Identifier_
@@ -168,6 +171,17 @@ All files ending in `*.j2` that aren't matched will simply get the `jinja2` file
 Accepts a regex string that is used to match the filename to determine if the file should use the Ansible filetype
 
 Can be used to avoid clashes with other files that are named the same - e.g. main.yaml used in github workflows by removing `main` from the regex
+
+##### g:ansible_doc_keywordprg (vim9script feature)
+
+(Does not exist in `neovim`.)
+
+`let g:ansible_doc_keywordprg = 1`
+
+If `ansible-doc` is installed you can lookup the keyword under cursor with `K`.
+
+Currently works for `keywords` and `modules`.
+
 
 ## Neovim
 
@@ -232,9 +246,9 @@ This behavior is not supported out of the box, but you can use [this snippet](ht
 
 You'll then be able to go to a role's definition with `<leader>gr`.
 
-## completion for the ansible builtin modules
+## completion for the ansible builtin modules (vim9script feature)
 
-*NOTE: This feature needs vim version >= 9.*
+(Does not exist in `neovim`.)
 
 After the pattern `ansible.builtin.` completion for the ansible builtin modules works with CTRL-X CTRL-O.
 

--- a/syntax/ansible.vim
+++ b/syntax/ansible.vim
@@ -30,6 +30,11 @@ endif
 let builtin_modules_file = expand("<sfile>:h:p") . "/builtin_modules.vim"
 execute "source " . builtin_modules_file
 
+if exists('g:ansible_doc_keywordprg') && g:ansible_doc_keywordprg != 0
+	let ansible_doc_file = expand("<sfile>:h:p") . "/ansible_doc.vim"
+	execute "source " . ansible_doc_file
+endif
+
 " Jinja
 " ================================
 

--- a/syntax/ansible_doc.vim
+++ b/syntax/ansible_doc.vim
@@ -1,0 +1,42 @@
+if !has('vim9script')
+	finish
+endif
+
+vim9script
+
+def LookupAnsibleDocFunc(word: string)
+	var lookup_output = ''
+
+	if ! executable('ansible-doc')
+		echo "ansible-doc is not installed."
+		return
+	endif
+
+	if len(ansible_keywords) == 0
+		ansible_keywords = ch_read(ansible_doc_job)
+
+		ak_dict = json_decode(ansible_keywords)
+	endif
+
+	if has_key(ak_dict, word)
+		lookup_output = system('ANSIBLE_NOCOLOR=true ansible-doc -t keyword '
+			.. word)
+	else
+		lookup_output = system('ANSIBLE_NOCOLOR=true ansible-doc ' .. word)
+	endif
+
+	echo lookup_output
+enddef
+
+var ansible_doc_job = job_start(['ansible-doc', '-j', '-t', 'keyword', '-l'],
+	{'drop': 'never', 'mode': 'raw', 'err_io': 'out', 'env': {'ANSIBLE_NOCOLOR': '1'}})
+
+var ansible_keywords = ''
+var ak_dict = {}
+
+set keywordprg=:LookupAnsibleDoc
+
+
+command! -nargs=1 LookupAnsibleDoc {
+	LookupAnsibleDocFunc("<args>")
+}


### PR DESCRIPTION
## Changes

#### Current Behavior

`K` triggers man pages.

#### New Behavior (vim9script / classic vim)

`K` triggers `ansible-doc` if installed and if vim was compiled with `+vim9script`.\
Otherwise it still triggers `man` pages.

Example for a keyword:
<img width="1046" height="207" alt="ansible-doc-keyword" src="https://github.com/user-attachments/assets/754c788a-169e-4faf-96e5-68334dc747e2" />

Example for a module:
<img width="1321" height="1025" alt="ansible-doc-module" src="https://github.com/user-attachments/assets/2abc409d-46bb-41c2-a00a-c858c98ffdad" />

`ansible-doc` is first called asynchronously to get a list of all \
ansible keywords.\
The reason behind this is that `ansible-doc` is slow python that would otherwise \
delay the start of `vim` (around the 400ms mark).\
When the user presses `K` for the first time the job is most likely finished \
otherwise we wait some more milliseconds.

It currently works for `keywords` and `modules`.

If `ansible-doc` is not installed, then `keywordprg` remains unchanged.\
(was not sure if it is better to display a message that it is not installed \
or to just stick with `man` as `keywordprg`)

## Rationale

Having `ansible-doc` as `keywordprg` in `ansible` files is usually more \
useful than `man`.

This will not work for `neovim` users, but they will probably use \
the ansible language server anyway and mostly use this plugin for file type \
detection. (?)\
So I think it should be fine.

The implementation is not super sophisticated (and somewhat slow as it is just calling an external python tool) but I use it regularly \
and it saves some time and effort, so I wanted to see if we can integrate it upstream.

PS: I also updated the `README.md` to clarify which features work in `neovim` and which features are `vim9script` only.